### PR TITLE
Changes IPython.parallel to new ipyparallel

### DIFF
--- a/src/dooplicity/emr_simulator.py
+++ b/src/dooplicity/emr_simulator.py
@@ -750,7 +750,7 @@ def run_simulation(branding, json_config, force, memcap, num_processes,
         # Using IPython?
         if ipy:
             try:
-                from IPython.parallel import Client
+                from ipyparallel import Client
             except ImportError:
                 iface.fail('IPython is required to run Dooplicity\'s EMR '
                            'simulator in --ipy mode. Visit ipython.org to '

--- a/src/rna/driver/rna_config.py
+++ b/src/rna/driver/rna_config.py
@@ -1399,7 +1399,7 @@ def ipython_client(ipython_profile=None, ipcontroller_json=None):
     """
     errors = []
     try:
-        from IPython.parallel import Client
+        from ipyparallel import Client
     except ImportError:
         errors.append(
                    'IPython is required to run Rail-RNA in '


### PR DESCRIPTION
Parallel has been moved out of IPython and into ipyparallel. Not a major issue, but throws a warning. This PR may break backwards compatibility, additional logic may be useful. This would be nice to incorporate before #34. 
