### PR TITLE
Upping bowtie2 to 2.3.2-legacy

### DIFF
--- a/src/dependency_urls.py
+++ b/src/dependency_urls.py
@@ -21,9 +21,9 @@ linux_dependencies = {
                  'http://verve.webfactional.com/mirror/linux/'
                  'bowtie-1.1.2-linux-x86_64.zip'],
     'bowtie2' : ['http://downloads.sourceforge.net/project/bowtie-bio/'
-                 'bowtie2/2.2.7/bowtie2-2.2.7-linux-x86_64.zip',
+                 'bowtie2/2.3.2/bowtie2-2.3.2-legacy-linux-x86_64.zip',
                  'http://verve.webfactional.com/mirror/linux/'
-                  'bowtie2-2.2.7-linux-x86_64.zip'],
+                  'bowtie2-2.3.2-legacy-linux-x86_64.zip'],
     'bedgraphtobigwig' : ['ftp://ftp.ccb.jhu.edu/pub/langmead/rail/'
                           'linux.x86_64/bedGraphToBigWig',
                           'http://verve.webfactional.com/mirror/linux/'
@@ -62,9 +62,9 @@ mac_dependencies = {
                  'http://verve.webfactional.com/mirror/mac/'
                  'bowtie-1.1.2-macos-x86_64.zip'],
     'bowtie2' : ['http://downloads.sourceforge.net/project/bowtie-bio/'
-                 'bowtie2/2.2.7/bowtie2-2.2.7-macos-x86_64.zip',
+                 'bowtie2/2.3.2/bowtie2-2.3.2-legacy-macos-x86_64.zip',
                  'http://verve.webfactional.com/mirror/mac/'
-                 'bowtie2-2.2.7-macos-x86_64.zip'],
+                 'bowtie2-2.3.2-legacy-macos-x86_64.zip'],
     'bedgraphtobigwig' : ['ftp://ftp.ccb.jhu.edu/pub/langmead/rail/'
                           'macOSX.x86_64/bedGraphToBigWig',
                           'http://verve.webfactional.com/mirror/mac/'

--- a/src/rna/driver/rna_installer.py
+++ b/src/rna/driver/rna_installer.py
@@ -424,20 +424,20 @@ class RailRnaInstaller(object):
                 samtools = os.path.join(self.final_install_dir,
                         self.depends['samtools'][0].rpartition('/')[2][:-8],
                         'samtools')
-                bowtie1_base = '-'.join(
-                    self.depends['bowtie1'][0].rpartition(
+                bowtie1_toks = self.depends['bowtie1'][0].rpartition(
                             '/'
-                        )[2].split('-')[:2]
-                )
+                        )[2].split('-')
+                bowtie1_legacy = len(bowtie1_toks) > 2 and bowtie1_toks[2] == 'legacy'
+                bowtie1_base = '-'.join(bowtie1_toks[:3 if bowtie1_legacy else 2])
                 bowtie1 = os.path.join(self.final_install_dir,
                                                 bowtie1_base, 'bowtie')
                 bowtie1_build = os.path.join(self.final_install_dir,
                                                 bowtie1_base, 'bowtie-build')
-                bowtie2_base = '-'.join(
-                    self.depends['bowtie2'][0].rpartition(
+                bowtie2_toks = self.depends['bowtie2'][0].rpartition(
                             '/'
-                        )[2].split('-')[:2]
-                )
+                        )[2].split('-')
+                bowtie2_legacy = len(bowtie2_toks) > 2 and bowtie2_toks[2] == 'legacy'
+                bowtie2_base = '-'.join(bowtie2_toks[:3 if bowtie2_legacy else 2])
                 bowtie2 = os.path.join(self.final_install_dir,
                                                 bowtie2_base, 'bowtie2')
                 bowtie2_build = os.path.join(self.final_install_dir,


### PR DESCRIPTION
Bowtie 2 with TBB still a problem, but bowtie2 2.3.2 otherwise solves the tabbed parsing issue that was preventing us from upgrading before.  I upgraded to 2.3.2 "legacy" version, which uses tinythreads instead of TBB.  I had to add a little parsing flexibility to `rna_installer.py` to deal with the trailing `-legacy` in the exploded directory name.  I could not get Bowtie 1 1.2.0 to work for mysterious reasons, but we should do that too eventually.