### PR TITLE
Don't add as much swap on EMR

### DIFF
--- a/src/rna/driver/rna_config.py
+++ b/src/rna/driver/rna_config.py
@@ -3376,7 +3376,7 @@ sudo ln -s /home/hadoop/.ncbi /home/.ncbi
                 'Name' : 'Allocate swap space',
                 'ScriptBootstrapAction' : {
                     'Args' : [
-                        '%d' % base.mem,
+                        '%d' % (base.mem / 16),
                         '/mnt/space/swapfile'
                     ],
                     'Path' : 's3://elasticmapreduce/bootstrap-actions/add-swap'


### PR DESCRIPTION
...since we discovered that it's not generally needed and it slows down bootstrapping excessively.