### PR TITLE
Fix issue with blank lines

### DIFF
--- a/src/rna/steps/preprocess.py
+++ b/src/rna/steps/preprocess.py
@@ -760,17 +760,17 @@ def go(nucleotides_per_input=8000000, gzip_output=True, gzip_level=3,
                         line_numbers = [i + 1 for i in line_numbers]
                         if any(is_none):
                             # TODO: better error handling
-                            print >> sys.stderr, 'Warning: some lines None at line numbers %s' % str(lines)
+                            print >>sys.stderr, 'Warning: some lines None at line numbers %s' % str(lines)
                             continue
                         lines = [line.strip() for line in lines]
                         lens = [len(line) for line in lines]
                         if sum(lens) == 0:
                             # TODO: better error handling
-                            print >> sys.stderr, 'Warning: all lines blank at line numbers %s' % str(lines)
+                            print >>sys.stderr, 'Warning: all lines blank at line numbers %s' % str(lines)
                             continue
                         if any([l == 0 for l in lens]):
                             # TODO: better error handling
-                            print >> sys.stderr, 'Warning: some blank at line numbers %s' % str(lines)
+                            print >>sys.stderr, 'Warning: some blank at line numbers %s' % str(lines)
                             continue
                         bad_record_skip = False
                         if lines[0][0] in fastq_cues:

--- a/src/rna/steps/preprocess.py
+++ b/src/rna/steps/preprocess.py
@@ -753,11 +753,25 @@ def go(nucleotides_per_input=8000000, gzip_output=True, gzip_level=3,
                             for source_stream in source_streams:
                                 lines.append(source_stream.readline())
                         read_next_line = True
-                        if not lines[0]:
+                        is_none = [line is None for line in lines]
+                        if all(is_none):
                             break_outer_loop = True
                             break
                         line_numbers = [i + 1 for i in line_numbers]
+                        if any(is_none):
+                            # TODO: better error handling
+                            print >> sys.stderr, 'Warning: some lines None at line numbers %s' % str(lines)
+                            continue
                         lines = [line.strip() for line in lines]
+                        lens = [len(line) for line in lines]
+                        if sum(lens) == 0:
+                            # TODO: better error handling
+                            print >> sys.stderr, 'Warning: all lines blank at line numbers %s' % str(lines)
+                            continue
+                        if any([l == 0 for l in lens]):
+                            # TODO: better error handling
+                            print >> sys.stderr, 'Warning: some blank at line numbers %s' % str(lines)
+                            continue
                         bad_record_skip = False
                         if lines[0][0] in fastq_cues:
                             if records_to_consume and not skipped:


### PR DESCRIPTION
This is a partial fix for a preprocessing "bug."  I encountered some ENCODE FASTQs that end in a blank line.  This caused a crash:

```
Traceback (most recent call last):
  File "app_main.py", line 75, in run_toplevel
  File "/usr/local/raildotbio/rail-rna/rna/steps/preprocess.py", line 1221, in <module>
    ignore_missing_sra_samples=args.ignore_missing_sra_samples)
  File "/usr/local/raildotbio/rail-rna/rna/steps/preprocess.py", line 762, in go
    if lines[0][0] in fastq_cues:
IndexError: string index out of range
```

This is my attempt to fix this and to clean up the sanity checks a bit.  But I would ask that you look it over, @buci, because my changes may not fit with your thinking about what ought to be a warning/error and how to handle `skip_bad_records`.