### PR TITLE
Ignore empty lines in credentials file

### DIFF
--- a/src/dooplicity/ansibles.py
+++ b/src/dooplicity/ansibles.py
@@ -550,6 +550,8 @@ def parsed_credentials(profile='default', base=None):
                             break
                     grab_roles = False
                     for line in config_stream:
+                        if len(line.strip()) == 0:
+                            continue
                         tokens = [token.strip() for token
                                     in line.strip().split('=')]
                         if tokens[0] == 'region' and not region_set:


### PR DESCRIPTION
My creds file has empty lines.  This allows Rail to deal with that sans barfing.