### PR TITLE
Fix create_bucket_command crash

### DIFF
--- a/src/dooplicity/ansibles.py
+++ b/src/dooplicity/ansibles.py
@@ -129,7 +129,7 @@ class S3Ansible(object):
                 raise RuntimeError(('Error "{}" encountered trying to list '
                                     'bucket with command "{}".').format(
                                             e.output, ' '.join(
-                                                    create_bucket_command
+                                                    check_bucket_command
                                                 )
                                         ))
             if 'NoSuchBucket' in e.output:


### PR DESCRIPTION
`create_bucket_command` isn't defined here, causing python error.  Think you meant `check_bucket_command `.  PyCharm is good about highlighting these things for you.