### PR TITLE
Add `--print-log-on-error` and robustify handling of bowtie archive names

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -74,6 +74,13 @@ if zipfile.is_zipfile(containing_dir):
             help=('symlinks all installed dependencies to /usr/local/bin if '
                   'installing for all users')
         )
+    parser.add_argument('--print-log-on-error', action='store_const',
+            const=True,
+            default=False,
+            help=('Print out the (long) installation log if there is an '
+                  'error.  By default, only the path to the log file is '
+                  'printed.')
+        )
     parser.add_argument('--curl', type=str, required=False, metavar='<exe>',
             default=exe_paths.curl,
             help=('path to cURL executable (def: %s)'
@@ -86,7 +93,9 @@ if zipfile.is_zipfile(containing_dir):
                             no_dependencies=args.no_dependencies,
                             prep_dependencies=args.prep_dependencies,
                             add_symlinks=args.symlink_dependencies,
-                            yes=args.yes, me=args.me) as railrna_installer:
+                            yes=args.yes, me=args.me,
+                            print_log_on_error=args.print_log_on_error) \
+            as railrna_installer:
         railrna_installer.install()
     sys.exit(0)
 

--- a/src/rna/driver/rna_config.py
+++ b/src/rna/driver/rna_config.py
@@ -3970,7 +3970,7 @@ class RailRnaPreprocess(object):
                 'ScriptBootstrapAction' : {
                     'Args' : [
                         base.elastic_rail_path, _jar_target,
-                        '-y', '-p', '-s'
+                        '-y', '-p', '-s', '--print-log-on-error'
                     ], # always say yes, only prep dependencies, and symlink  
                     'Path' : base.install_rail_bootstrap
                 }


### PR DESCRIPTION
The code for exploding the bowtie archives and setting the Bowtie binary name was failing for 2.3.3.1, which is our (Bowtie's) fault because we keep changing the policy about what the post-decompression subdirectory is named.  In particular we have been changing how many dash-separated tokens there are.    This fixes that is a rather permanent way and also adds a new `--print-log-on-error` option that asks rail to cat the whole install log to stderr upon failure, rather than directing the user to a log file that, in the case of EMR runs, disappeared with the cluster.