### PR TITLE
Travis: Change bowtie/bowtie2 unzip commands so subdir name doesn't matter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
       pip install weave;
     fi
   - conda install --yes samtools bedtools ucsc-bigwigtobedgraph
-  - cd src && export BOWTIE1=$(python -c "from dependency_urls import linux_dependencies; print linux_dependencies['bowtie1'][0]") && export BOWTIE2=$(python -c "from dependency_urls import linux_dependencies; print linux_dependencies['bowtie2'][0]") && wget ${BOWTIE1} && wget ${BOWTIE2} && unzip $(basename ${BOWTIE1}) && unzip $(basename ${BOWTIE2}) && export PATH=${PATH}:$(cd $(echo $(basename ${BOWTIE1}) | rev | cut -d'.' -f2- | cut -d'-' -f3- | rev) && pwd):$(cd $(echo $(basename ${BOWTIE2}) | rev | cut -d'.' -f2- | cut -d'-' -f3- | rev) && pwd) && cd ..
+  - cd src && export BOWTIE1=$(python -c "from dependency_urls import linux_dependencies; print linux_dependencies['bowtie1'][0]") && export BOWTIE2=$(python -c "from dependency_urls import linux_dependencies; print linux_dependencies['bowtie2'][0]") && wget ${BOWTIE1} && wget ${BOWTIE2} && unzip -j -d bowtie1 $(basename ${BOWTIE1}) && unzip -j -d bowtie2 $(basename ${BOWTIE2}) && export PATH=${PATH}:$(pwd)/bowtie1:$(pwd)/bowtie2 && cd ..
   - which bowtie
   - bowtie --version
   - which bowtie2


### PR DESCRIPTION
This doesn't fix all travis issues (line test still dies) but it does fix the issue caused by the bowtie/bowtie2 subdirectory name not being predictably tokenizable.  Switches to using `unzip -j` ("junks" the subdirectory structure) so that subdirectory names can't mess it up.