### PR TITLE
Quote lifecycle rules when calling `put-bucket-lifecycle`

### DIFF
--- a/src/dooplicity/ansibles.py
+++ b/src/dooplicity/ansibles.py
@@ -394,7 +394,7 @@ class S3Ansible(object):
                             [self.aws, '--profile', self.profile,
                              's3api', 'put-bucket-lifecycle', '--bucket',
                              bucket, '--lifecycle-configuration',
-                                                '{"Rules":%s}'
+                                                '\'{"Rules":%s}\''
                                                 % json.dumps(rules),
                             '>/dev/null']
                         )


### PR DESCRIPTION
This fixes an issue whereby `aws` complained about a bad command because of lack of quotes around the lifecycle rules.  Error below:

+ python /Users/langmead/git/rail-langmead/src align elastic --profile dlt-langmead -m s3://langmeadlab-public-ct-mouse/ct_mouse_sc/manifest/ct_mouse_sc.manifest -i s3://langmeadlab-public-ct-mouse/ct_mouse_sc/preproc --intermediate s3://langmeadlab-public-ct-mouse/ct_mouse_sc/intermediate -o s3://langmeadlab-public-ct-mouse/ct_mouse_sc/output -a mm10 --drop-deletions --region us-east-1 --core-instance-bid-price 0.50 --core-instance-type c4.8xlarge --task-instance-bid-price 0.50 --task-instance-type c4.8xlarge --master-instance-bid-price 0.50 --master-instance-type c4.8xlarge --master-instance-count 1 --core-instance-count 10 --task-instance-count 0 --ec2-subnet-id subnet-32c91c1d --use-ebs --ebs-volume-type gp2 --ebs-volumes-per-instance 8 --ebs-gb 100 --ec2-key-name ct1 -d idx,tsv,bed,bw,jx --name 'Celltower mouse SC' --transcriptome-bowtie2-args '--thread-ceiling 32 --thread-piddir /tmp/transcriptome-bowtie2-pid-tmp' --bowtie2-args '--thread-ceiling 32 --thread-piddir /tmp/bowtie2-pid-tmp' --genome-bowtie1-args '--thread-ceiling 32 --thread-piddir /tmp/bowtie-pid-tmp' --visible-to-all-users --emr-debug
Loading...
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help

Unknown options: Prefix:, ct_mouse_sc/preproc.intermediate/,, Expiration:, {Days:, 4},, ID:, MjMzNzhiZjItN2U0Ni00YTY1LTkxNTctODcwZDMxN2VhZmM4},, {Status:, Enabled,, Prefix:, ct_mouse_sc/preproc.dependencies/,, Expiration:, {Days:, 4},, ID:, Mjg1MzdmMDktMzc3OS00YzliLTgyNTAtYjQ5MWFkMDRlMmIy},, {Status:, Enabled,, Prefix:, ct_mouse_bulk/preproc.intermediate/,, Expiration:, {Days:, 4},, ID:, MjFhMzUwYjAtNTY4ZC00MTkzLTkzNWUtNDA1ZDU2MTQzZjZm},, {Status:, Enabled,, Prefix:, ct_mouse_bulk/preproc.dependencies/,, Expiration:, {Days:, 4},, ID:, NmY1MjgyZDEtOTRhNS00NGZkLWFiMWYtZTU2MTBmMDljMjI2},, {Status:, Enabled,, Prefix:, ct_mouse_sc/intermediate/,, Expiration:, {Days:, 4}}]}, Enabled,
Traceback (most recent call last):
  File "/Users/langmead/anaconda/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/Users/langmead/anaconda/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/langmead/git/rail-langmead/src/__main__.py", line 1088, in <module>
    ebs_volumes_per_instance=args.ebs_volumes_per_instance
  File "/Users/langmead/git/rail-langmead/src/rna/driver/rna_config.py", line 6269, in __init__
    ebs_volumes_per_instance=ebs_volumes_per_instance)
  File "/Users/langmead/git/rail-langmead/src/rna/driver/rna_config.py", line 2273, in __init__
    days=intermediate_lifetime
  File "/Users/langmead/git/rail-langmead/src/dooplicity/ansibles.py", line 408, in expire_prefix
    aws_command
RuntimeError: Error encountered changing lifecycleparameters with command "aws --profile dlt-langmead s3api put-bucket-lifecycle --bucket langmeadlab-public-ct-mouse --lifecycle-configuration {"Rules":[{"Status": "Enabled", "Prefix": "ct_mouse_sc/preproc.intermediate/", "Expiration": {"Days": 4}, "ID": "MjMzNzhiZjItN2U0Ni00YTY1LTkxNTctODcwZDMxN2VhZmM4"}, {"Status": "Enabled", "Prefix": "ct_mouse_sc/preproc.dependencies/", "Expiration": {"Days": 4}, "ID": "Mjg1MzdmMDktMzc3OS00YzliLTgyNTAtYjQ5MWFkMDRlMmIy"}, {"Status": "Enabled", "Prefix": "ct_mouse_bulk/preproc.intermediate/", "Expiration": {"Days": 4}, "ID": "MjFhMzUwYjAtNTY4ZC00MTkzLTkzNWUtNDA1ZDU2MTQzZjZm"}, {"Status": "Enabled", "Prefix": "ct_mouse_bulk/preproc.dependencies/", "Expiration": {"Days": 4}, "ID": "NmY1MjgyZDEtOTRhNS00NGZkLWFiMWYtZTU2MTBmMDljMjI2"}, {"Status": "Enabled", "Prefix": "ct_mouse_sc/intermediate/", "Expiration": {"Days": 4}}]} >/dev/null".